### PR TITLE
chore(deps): actualización de dependencias principales ⬆️ #13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu.</groupId>
@@ -38,7 +38,7 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
-            <version>9.1.0</version>
+            <version>9.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.4</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
* actualiza spring-boot-starter-parent de 3.4.1 a 3.4.2
* actualiza mysql-connector-j de 9.1.0 a 9.2.0
* actualiza springdoc-openapi-starter-webmvc-ui de 2.7.0 a 2.8.4

Closes #13