### PR TITLE
build: upgrade dependencies and release version 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,13 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 ### Removed
 - Maven wrapper script for Windows
 
-## [Unreleased]
+## [0.0.2] - 2026-02-02
+### Changed
+- Upgrade Spring Boot from 4.0.0-M3 to 4.0.2
+- Upgrade MySQL Connector/J from 9.4.0 to 9.6.0
+- Upgrade SpringDoc OpenAPI from 3.0.0-M1 to 3.0.1
+- Upgrade Apache Commons Lang3 from 3.19.0 to 3.20.0
+- Remove executable configuration from spring-boot-maven-plugin
 
 ## [0.0.1-SNAPSHOT] - 2024-03-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Servicio core para la gestión documental de la Universidad de Manizales. Este m
 
 ## Tecnologías
 - Java 25
-- Spring Boot 4.0.0-M3
+- Spring Boot 4.0.2
 - Spring Data JPA
-- MySQL 9.4.0
-- SpringDoc OpenAPI 3.0.0-M1 (Swagger)
+- MySQL 9.6.0
+- SpringDoc OpenAPI 3.0.1 (Swagger)
 - Lombok
 - Hibernate Validator 9.0.0.Beta3
 - Spring Boot Actuator
 - Spring Security
-- Apache Commons Lang 3
+- Apache Commons Lang 3.20.0
 - H2 Database (para pruebas)
 - JaCoCo (cobertura de código)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M3</version>
+        <version>4.0.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu.</groupId>
     <artifactId>um.docum.rest</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2</version>
     <name>um.docum.rest</name>
     <description>Docum</description>
     <properties>
@@ -42,7 +42,7 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
-            <version>9.4.0</version>
+            <version>9.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.0-M1</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.19.0</version>
+                <version>3.20.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -86,9 +86,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Closes #21

## Descripción
Actualización de dependencias y versionamiento del proyecto a la versión 0.0.2. Mejora la estabilidad, seguridad y rendimiento del sistema al actualizar a versiones más recientes de las bibliotecas principales.

## Cambios Realizados
- Upgrade Spring Boot from 4.0.0-M3 to 4.0.2
- Upgrade MySQL Connector/J from 9.4.0 to 9.6.0
- Upgrade SpringDoc OpenAPI from 3.0.0-M1 to 3.0.1
- Upgrade Apache Commons Lang3 from 3.19.0 to 3.20.0
- Remove executable configuration from spring-boot-maven-plugin
- Update project version to 0.0.2 in pom.xml
- Update documentation in README.md and CHANGELOG.md

## Verificación
- Build: ✅ Maven build passes with new dependencies
- Documentation: ✅ CHANGELOG.md and README.md updated
- Semantic Versioning: ✅ Project version incremented correctly
