### PR TITLE
ci(actions): upgrade GitHub Actions and Docker Actions to latest versions

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -267,4 +267,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,3 @@
-# This workflow builds two Docker images in parallel:
-# 1. A standard JVM image.
-# 2. A GraalVM native image.
-# It then pushes both to a container registry.
 
 name: UM.docum.core-service Build JVM Image
 
@@ -17,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -58,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -79,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2026-04-04
+### Changed
+- Upgrade GitHub Actions: checkout@v4→v6, setup-java@v4→v5, cache@v4→v5, deploy-pages@v4→v5
+- Upgrade Docker Actions: login-action@v3→v4, metadata-action@v5→v6, setup-buildx-action@v3→v4, build-push-action@v6→v7
+
 ## [0.0.3] - 2026-04-03
 ### Changed
 - Upgrade Spring Boot from 4.0.2 to 4.0.5

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>ar.edu.</groupId>
     <artifactId>um.docum.rest</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <name>um.docum.rest</name>
     <description>Docum</description>
     <properties>


### PR DESCRIPTION
Closes #25

## Descripción
Actualización de dependencias de GitHub Actions y Docker Actions a sus últimas versiones disponibles.

## Cambios Realizados
- `.github/workflows/generate-docs.yml`: Upgrade de actions/checkout@v4→v6, actions/setup-java@v4→v5, actions/deploy-pages@v4→v5
- `.github/workflows/maven.yml`: Upgrade de actions/checkout@v4→v6, actions/setup-java@v4→v5, actions/cache@v4→v5, actions/deploy-pages@v4→v5, docker/login-action@v3→v4, docker/metadata-action@v5→v6, docker/setup-buildx-action@v3→v4, docker/build-push-action@v6→v7. Eliminación de comentario descriptivo.
- `CHANGELOG.md`: Agregada entrada para versión `[0.0.4]`
- `pom.xml`: Actualización de versión de `0.0.3` → `0.0.4`

## Verificación
- Los workflows de GitHub Actions se ejecutan correctamente tras las actualizaciones
- Los Docker actions funcionan con las nuevas versiones